### PR TITLE
fix(frontend): Stop production localhost fallback #21

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,7 +66,7 @@ This guide demonstrates all implemented features of the Student Progress Monitor
 - Chat history persisted in database
 
 **Endpoints:**
-- `WebSocket /chat/ws/{group_id}?token={jwt}` - WebSocket connection
+- `WebSocket /chat/ws/{group_id}` - WebSocket connection (send `{"type":"auth","token":"<jwt>"}` first)
 - `GET /chat/{group_id}/messages` - Get message history
 
 ### ✅ 5. Progress Monitoring

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ npm run dev
 
 App: http://localhost:3000
 
+### Production Deployment
+
+The checked-in `vercel.json` deploys the frontend only. This project's backend uses SQLite persistence and FastAPI WebSockets, so it should be deployed on a stateful platform instead of Vercel.
+
+Use the root `render.yaml` to deploy the backend to Render, then:
+1. Copy the backend origin (for example `https://scio-assignment-2026-backend.onrender.com`).
+2. Add `{backend-origin}/auth/google/callback` to your Google OAuth authorized redirect URIs.
+3. Set `VITE_API_URL={backend-origin}` in Vercel.
+4. Ensure the backend `FRONTEND_URL` is `https://scio-assignment-2026.vercel.app`.
+
 ## Google OAuth2 Setup
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com)

--- a/README.md
+++ b/README.md
@@ -118,11 +118,34 @@ App: http://localhost:3000
 
 The checked-in `vercel.json` deploys the frontend only. This project's backend uses SQLite persistence and FastAPI WebSockets, so it should be deployed on a stateful platform instead of Vercel.
 
-Use the root `render.yaml` to deploy the backend to Render, then:
-1. Copy the backend origin (for example `https://scio-assignment-2026-backend.onrender.com`).
-2. Add `{backend-origin}/auth/google/callback` to your Google OAuth authorized redirect URIs.
-3. Set `VITE_API_URL={backend-origin}` in Vercel.
-4. Ensure the backend `FRONTEND_URL` is `https://scio-assignment-2026.vercel.app`.
+#### Deploy the backend on Render
+
+1. Create a [Render](https://render.com) account and connect your GitHub account in the Render dashboard.
+2. In Render, click **New** → **Blueprint**.
+3. Select this repository and the branch you want to deploy. Render reads the root `render.yaml` automatically.
+4. Review the detected service:
+   - Service name: `scio-assignment-2026-backend`
+   - Runtime: Python
+   - Root directory: `backend`
+   - Plan: `starter`
+   - Persistent disk mounted at `/var/data` for the SQLite database
+5. Enter the environment variables Render prompts you for:
+   - `GOOGLE_CLIENT_ID`
+   - `GOOGLE_CLIENT_SECRET`
+
+   `SECRET_KEY` is generated automatically by Render. `DATABASE_URL`, `FRONTEND_URL`, and `ENVIRONMENT` are already set by `render.yaml`.
+6. Click **Create Blueprint** and wait for the deploy to finish.
+7. Open the new Render service and copy its public URL, for example `https://scio-assignment-2026-backend.onrender.com`.
+
+#### Finish Google OAuth and Vercel
+
+1. In [Google Cloud Console](https://console.cloud.google.com), open your OAuth client and add this authorized redirect URI:
+   - `{backend-origin}/auth/google/callback`
+2. In Vercel, open the `scio-assignment-2026` project settings and add:
+   - `VITE_API_URL={backend-origin}`
+3. Redeploy the Vercel frontend.
+
+If your frontend will not live at `https://scio-assignment-2026.vercel.app`, update `FRONTEND_URL` in the Render service settings to match the real frontend origin.
 
 ## Google OAuth2 Setup
 
@@ -131,6 +154,7 @@ Use the root `render.yaml` to deploy the backend to Render, then:
 3. Configure the OAuth consent screen (APIs & Services → OAuth consent screen)
 4. Create an OAuth 2.0 Client ID (Web application) under APIs & Services → Credentials
 5. In the client configuration, add the authorized redirect URI: `http://localhost:8000/auth/google/callback`
+   - For production, add your deployed backend callback too: `https://<your-render-service>.onrender.com/auth/google/callback`
 6. Copy the Client ID and Client Secret into the backend `.env` file
 
 ## Usage

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,8 @@ ENVIRONMENT=development
 # Google OAuth2
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+# Optional override. If unset, the backend uses the current request origin
+# and appends /auth/google/callback automatically.
 GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
 
 # Database

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,10 +47,15 @@ API documentation: `http://localhost:8000/docs`
 
 The repository root includes `render.yaml` for deploying this backend with a persistent disk-backed SQLite database.
 
-After the Render service is live:
-- Add `https://<your-render-service>.onrender.com/auth/google/callback` to your Google OAuth authorized redirect URIs.
-- Set `FRONTEND_URL` to your Vercel frontend URL.
-- Set `VITE_API_URL` in Vercel to `https://<your-render-service>.onrender.com`.
+Step-by-step:
+1. In Render, click **New** → **Blueprint** and select this repository.
+2. Keep the detected backend service from `render.yaml`.
+3. Enter `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` when Render prompts for them.
+4. Create the Blueprint and wait for the service URL.
+5. Add `https://<your-render-service>.onrender.com/auth/google/callback` to your Google OAuth authorized redirect URIs.
+6. Set `VITE_API_URL` in Vercel to `https://<your-render-service>.onrender.com`.
+
+See the root `README.md` Production Deployment section for the full Render + Vercel flow.
 
 ## API Endpoints
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,7 +73,7 @@ See the root `README.md` Production Deployment section for the full Render + Ver
 - `GET /groups/{group_id}/members` - Get group members (teacher only)
 
 ### Chat
-- `WebSocket /chat/ws/{group_id}?token={jwt_token}` - WebSocket for real-time chat
+- `WebSocket /chat/ws/{group_id}` - WebSocket for real-time chat (send `{"type":"auth","token":"<jwt>"}` as the first message)
 - `GET /chat/{group_id}/messages` - Get message history
 - `GET /chat/{group_id}/progress` - Get student progress (teacher only)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,15 @@ The API will be available at `http://localhost:8000`
 
 API documentation: `http://localhost:8000/docs`
 
+## Render deployment
+
+The repository root includes `render.yaml` for deploying this backend with a persistent disk-backed SQLite database.
+
+After the Render service is live:
+- Add `https://<your-render-service>.onrender.com/auth/google/callback` to your Google OAuth authorized redirect URIs.
+- Set `FRONTEND_URL` to your Vercel frontend URL.
+- Set `VITE_API_URL` in Vercel to `https://<your-render-service>.onrender.com`.
+
 ## API Endpoints
 
 ### Authentication

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -29,7 +29,22 @@ def get_google_redirect_uri(request: Request) -> str:
     if configured_redirect_uri:
         return configured_redirect_uri
 
-    return str(request.url_for('google_callback'))
+    callback_url = str(request.url_for('google_callback'))
+    parsed_callback_url = urlparse(callback_url)
+    callback_host = parsed_callback_url.hostname or ""
+
+    if parsed_callback_url.scheme != "https" and callback_host not in {"localhost", "127.0.0.1"}:
+        logger.error(
+            "Derived Google redirect URI %s is not HTTPS. "
+            "Set GOOGLE_REDIRECT_URI explicitly for this deployment.",
+            callback_url,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Server OAuth configuration error: set GOOGLE_REDIRECT_URI for this deployment.",
+        )
+
+    return callback_url
 
 # OAuth configuration
 oauth = OAuth()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -22,6 +22,15 @@ router = APIRouter()
 # Default frontend URL for fallback scenarios
 DEFAULT_FRONTEND_URL = "http://localhost:3000"
 
+
+def get_google_redirect_uri(request: Request) -> str:
+    """Resolve the OAuth callback URL from config or the current backend origin."""
+    configured_redirect_uri = os.getenv('GOOGLE_REDIRECT_URI')
+    if configured_redirect_uri:
+        return configured_redirect_uri
+
+    return str(request.url_for('google_callback'))
+
 # OAuth configuration
 oauth = OAuth()
 oauth.register(
@@ -38,7 +47,7 @@ oauth.register(
 @router.get("/google")
 async def google_login(request: Request):
     """Initiate Google OAuth2 login flow"""
-    redirect_uri = os.getenv('GOOGLE_REDIRECT_URI', 'http://localhost:8000/auth/google/callback')
+    redirect_uri = get_google_redirect_uri(request)
     
     # Return the authorization redirect response directly
     return await oauth.google.authorize_redirect(request, redirect_uri)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -18,8 +18,7 @@ class ConnectionManager:
     def __init__(self):
         self.active_connections: Dict[int, List[WebSocket]] = {}
     
-    async def connect(self, websocket: WebSocket, group_id: int):
-        await websocket.accept()
+    def connect(self, websocket: WebSocket, group_id: int):
         if group_id not in self.active_connections:
             self.active_connections[group_id] = []
         self.active_connections[group_id].append(websocket)
@@ -55,37 +54,67 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
+async def close_unauthorized_websocket(websocket: WebSocket):
+    await websocket.close(code=1008)
+
+
 @router.websocket("/ws/{group_id}")
-async def websocket_endpoint(websocket: WebSocket, group_id: int, token: str):
+async def websocket_endpoint(websocket: WebSocket, group_id: int):
     """WebSocket endpoint for real-time chat and progress updates"""
-    # Verify token
+    await websocket.accept()
+
+    try:
+        auth_data = json.loads(await websocket.receive_text())
+    except WebSocketDisconnect:
+        return
+    except json.JSONDecodeError:
+        await close_unauthorized_websocket(websocket)
+        return
+
+    if not isinstance(auth_data, dict):
+        await close_unauthorized_websocket(websocket)
+        return
+
+    if auth_data.get("type") != "auth":
+        await close_unauthorized_websocket(websocket)
+        return
+
+    token = auth_data.get("token")
+    if not isinstance(token, str) or not token:
+        await close_unauthorized_websocket(websocket)
+        return
+
     payload = verify_token(token)
     if not payload:
-        await websocket.close(code=1008)
+        await close_unauthorized_websocket(websocket)
         return
-    
-    user_id = payload.get("sub")
-    
-    # Get database session
+
+    user_id_raw = payload.get("sub")
+    try:
+        user_id = int(user_id_raw)
+    except (TypeError, ValueError):
+        await close_unauthorized_websocket(websocket)
+        return
+
     db = next(get_db())
-    
+
     try:
         # Verify user exists
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            await websocket.close(code=1008)
+            await close_unauthorized_websocket(websocket)
             return
         
         # Verify group exists
         group = db.query(Group).filter(Group.id == group_id).first()
         if not group:
-            await websocket.close(code=1008)
+            await close_unauthorized_websocket(websocket)
             return
         
         # Verify authorization
         if user.role == "teacher":
             if group.teacher_id != user_id:
-                await websocket.close(code=1008)
+                await close_unauthorized_websocket(websocket)
                 return
         else:
             membership = db.query(GroupMembership).filter(
@@ -93,11 +122,11 @@ async def websocket_endpoint(websocket: WebSocket, group_id: int, token: str):
                 GroupMembership.group_id == group_id
             ).first()
             if not membership:
-                await websocket.close(code=1008)
+                await close_unauthorized_websocket(websocket)
                 return
         
         # Connect
-        await manager.connect(websocket, group_id)
+        manager.connect(websocket, group_id)
         
         # Send connection confirmation
         await websocket.send_json({

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -75,6 +75,9 @@ async def websocket_endpoint(websocket: WebSocket, group_id: int):
         )
     except WebSocketDisconnect:
         return
+    except RuntimeError:
+        await close_unauthorized_websocket(websocket)
+        return
     except asyncio.TimeoutError:
         logger.warning("WebSocket auth handshake timed out for group %s", group_id)
         await close_unauthorized_websocket(websocket)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 from typing import List, Dict
@@ -53,6 +54,8 @@ class ConnectionManager:
 
 manager = ConnectionManager()
 
+AUTH_HANDSHAKE_TIMEOUT_SECONDS = 5
+
 
 async def close_unauthorized_websocket(websocket: WebSocket):
     await websocket.close(code=1008)
@@ -64,8 +67,17 @@ async def websocket_endpoint(websocket: WebSocket, group_id: int):
     await websocket.accept()
 
     try:
-        auth_data = json.loads(await websocket.receive_text())
+        auth_data = json.loads(
+            await asyncio.wait_for(
+                websocket.receive_text(),
+                timeout=AUTH_HANDSHAKE_TIMEOUT_SECONDS,
+            )
+        )
     except WebSocketDisconnect:
+        return
+    except asyncio.TimeoutError:
+        logger.warning("WebSocket auth handshake timed out for group %s", group_id)
+        await close_unauthorized_websocket(websocket)
         return
     except json.JSONDecodeError:
         await close_unauthorized_websocket(websocket)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,6 +43,8 @@ The repository root includes `vercel.json`, so Vercel installs dependencies from
 
 Set `VITE_API_URL` in the Vercel project to the public base URL of your backend API before deploying.
 
+Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing, the login page is disabled and shows a configuration error instead of redirecting to localhost.
+
 ## Project Structure
 
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,7 +41,9 @@ npm run build
 
 The repository root includes `vercel.json`, so Vercel installs dependencies from `frontend/`, runs the frontend build there, and publishes `frontend/dist`.
 
-Set `VITE_API_URL` in the Vercel project to the public base URL of your backend API before deploying.
+Vercel only deploys the frontend for this repository. The FastAPI backend uses SQLite persistence and WebSockets, so it must be deployed separately on a stateful platform such as Render.
+
+Use the root `render.yaml` to deploy the backend, then set `VITE_API_URL` in the Vercel project to the backend origin (for example `https://scio-assignment-2026-backend.onrender.com`).
 
 Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing or invalid, the login page is disabled and shows a configuration error instead of redirecting to localhost.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,7 +43,7 @@ The repository root includes `vercel.json`, so Vercel installs dependencies from
 
 Set `VITE_API_URL` in the Vercel project to the public base URL of your backend API before deploying.
 
-Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing, the login page is disabled and shows a configuration error instead of redirecting to localhost.
+Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing or invalid, the login page is disabled and shows a configuration error instead of redirecting to localhost.
 
 ## Project Structure
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,8 +45,6 @@ Set `VITE_API_URL` in the Vercel project to the public base URL of your backend 
 
 Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing, the login page is disabled and shows a configuration error instead of redirecting to localhost.
 
-Vercel builds now also fail fast when `VITE_API_URL` is unset, which prevents publishing another broken deployment.
-
 ## Project Structure
 
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,6 +45,8 @@ Vercel only deploys the frontend for this repository. The FastAPI backend uses S
 
 Use the root `render.yaml` to deploy the backend, then set `VITE_API_URL` in the Vercel project to the backend origin (for example `https://scio-assignment-2026-backend.onrender.com`).
 
+See the root `README.md` Production Deployment section for step-by-step Render instructions.
+
 Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing or invalid, the login page is disabled and shows a configuration error instead of redirecting to localhost.
 
 ## Project Structure

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,6 +45,8 @@ Set `VITE_API_URL` in the Vercel project to the public base URL of your backend 
 
 Production builds no longer fall back to `http://localhost:8000`. If `VITE_API_URL` is missing, the login page is disabled and shows a configuration error instead of redirecting to localhost.
 
+Vercel builds now also fail fast when `VITE_API_URL` is unset, which prevents publishing another broken deployment.
+
 ## Project Structure
 
 ```

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -6,18 +6,42 @@ function normalizeApiBaseUrl(value: string): string {
   return value.replace(/\/+$/, '');
 }
 
+function parseConfiguredApiBaseUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+
+    return normalizeApiBaseUrl(url.toString());
+  } catch {
+    return null;
+  }
+}
+
+const validConfiguredApiBaseUrl = configuredApiBaseUrl
+  ? parseConfiguredApiBaseUrl(configuredApiBaseUrl)
+  : null;
+
 export const apiConfigurationError =
   !configuredApiBaseUrl && !import.meta.env.DEV
-    ? 'Authentication is unavailable because this deployment is missing VITE_API_URL.'
-    : null;
+    ? 'The backend API is unavailable because this deployment is missing VITE_API_URL.'
+    : configuredApiBaseUrl && !validConfiguredApiBaseUrl
+      ? 'The backend API is unavailable because VITE_API_URL must be an absolute http(s) URL.'
+      : null;
 
 function requireApiBaseUrl(): string {
-  if (configuredApiBaseUrl) {
-    return normalizeApiBaseUrl(configuredApiBaseUrl);
+  if (validConfiguredApiBaseUrl) {
+    return validConfiguredApiBaseUrl;
   }
 
-  if (import.meta.env.DEV) {
+  if (!configuredApiBaseUrl && import.meta.env.DEV) {
     return DEV_API_BASE_URL;
+  }
+
+  if (configuredApiBaseUrl) {
+    throw new Error('VITE_API_URL must be an absolute URL starting with http:// or https://.');
   }
 
   throw new Error('VITE_API_URL must be set to the public backend URL for production deployments.');

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,44 @@
+const DEV_API_BASE_URL = 'http://localhost:8000';
+
+const configuredApiBaseUrl = import.meta.env.VITE_API_URL?.trim();
+
+function normalizeApiBaseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export const apiConfigurationError =
+  !configuredApiBaseUrl && !import.meta.env.DEV
+    ? 'Authentication is unavailable because this deployment is missing VITE_API_URL.'
+    : null;
+
+function requireApiBaseUrl(): string {
+  if (configuredApiBaseUrl) {
+    return normalizeApiBaseUrl(configuredApiBaseUrl);
+  }
+
+  if (import.meta.env.DEV) {
+    return DEV_API_BASE_URL;
+  }
+
+  throw new Error('VITE_API_URL must be set to the public backend URL for production deployments.');
+}
+
+export function buildApiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${requireApiBaseUrl()}${normalizedPath}`;
+}
+
+export function buildWebSocketUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const apiBaseUrl = requireApiBaseUrl();
+
+  if (apiBaseUrl.startsWith('https://')) {
+    return `wss://${apiBaseUrl.slice('https://'.length)}${normalizedPath}`;
+  }
+
+  if (apiBaseUrl.startsWith('http://')) {
+    return `ws://${apiBaseUrl.slice('http://'.length)}${normalizedPath}`;
+  }
+
+  throw new Error('VITE_API_URL must start with http:// or https://.');
+}

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -26,9 +26,9 @@ const validConfiguredApiBaseUrl = configuredApiBaseUrl
 
 export const apiConfigurationError =
   !configuredApiBaseUrl && !import.meta.env.DEV
-    ? 'The backend API is unavailable because this deployment is missing VITE_API_URL.'
+    ? 'The backend API is unavailable because this deployment is missing VITE_API_URL. Deploy the FastAPI backend and set VITE_API_URL to its public base URL.'
     : configuredApiBaseUrl && !validConfiguredApiBaseUrl
-      ? 'The backend API is unavailable because VITE_API_URL must be an absolute http(s) URL.'
+      ? 'The backend API is unavailable because VITE_API_URL must be an absolute http(s) URL for the deployed backend.'
       : null;
 
 function requireApiBaseUrl(): string {

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -14,7 +14,11 @@ function parseConfiguredApiBaseUrl(value: string): string | null {
       return null;
     }
 
-    return normalizeApiBaseUrl(url.toString());
+    if (url.search || url.hash || url.username || url.password) {
+      return null;
+    }
+
+    return normalizeApiBaseUrl(`${url.origin}${url.pathname}`);
   } catch {
     return null;
   }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+import { apiConfigurationError, buildApiUrl } from '../config/api';
 
 const Login: React.FC = () => {
+  const loginDisabled = Boolean(apiConfigurationError);
+
   const handleGoogleLogin = () => {
-    // Redirect to Google OAuth
-    window.location.href = `${API_BASE_URL}/auth/google`;
+    if (loginDisabled) {
+      return;
+    }
+
+    window.location.href = buildApiUrl('/auth/google');
   };
 
   return (
@@ -18,8 +22,16 @@ const Login: React.FC = () => {
           <p style={styles.description}>
             Sign in with your Google account to get started.
           </p>
+
+          {apiConfigurationError && (
+            <p style={styles.error}>{apiConfigurationError}</p>
+          )}
           
-          <button onClick={handleGoogleLogin} style={styles.button}>
+          <button
+            onClick={handleGoogleLogin}
+            style={loginDisabled ? { ...styles.button, ...styles.buttonDisabled } : styles.button}
+            disabled={loginDisabled}
+          >
             <svg style={styles.icon} viewBox="0 0 24 24">
               <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
               <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
@@ -75,6 +87,13 @@ const styles: { [key: string]: React.CSSProperties } = {
     textAlign: 'center',
     lineHeight: '1.5',
   },
+  error: {
+    fontSize: '14px',
+    color: '#b00020',
+    textAlign: 'center',
+    lineHeight: '1.5',
+    margin: 0,
+  },
   button: {
     display: 'flex',
     alignItems: 'center',
@@ -89,6 +108,10 @@ const styles: { [key: string]: React.CSSProperties } = {
     borderRadius: '4px',
     cursor: 'pointer',
     transition: 'all 0.2s',
+  },
+  buttonDisabled: {
+    cursor: 'not-allowed',
+    opacity: 0.6,
   },
   icon: {
     width: '24px',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -114,7 +114,16 @@ class ApiService {
 
   // WebSocket
   createWebSocket(groupId: number, token: string): WebSocket {
-    return new WebSocket(buildWebSocketUrl(`/chat/ws/${groupId}?token=${encodeURIComponent(token)}`));
+    const websocket = new WebSocket(buildWebSocketUrl(`/chat/ws/${groupId}`));
+
+    websocket.addEventListener('open', () => {
+      websocket.send(JSON.stringify({
+        type: 'auth',
+        token,
+      }));
+    });
+
+    return websocket;
   }
 }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,5 @@
 import { User, Group, GroupWithQR, Message, ProgressEstimate } from '../types';
-
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+import { buildApiUrl, buildWebSocketUrl } from '../config/api';
 
 class ApiService {
   private getHeaders(token?: string): HeadersInit {
@@ -52,12 +51,12 @@ class ApiService {
 
   // Authentication
   async getCurrentUser(token: string): Promise<User> {
-    return this.request<User>(`${API_BASE_URL}/auth/me`, {}, token);
+    return this.request<User>(buildApiUrl('/auth/me'), {}, token);
   }
 
   async setUserRole(userId: number, role: 'teacher' | 'student', token: string): Promise<any> {
     return this.request<any>(
-      `${API_BASE_URL}/auth/set-role/${userId}?role=${role}`,
+      buildApiUrl(`/auth/set-role/${userId}?role=${role}`),
       { method: 'POST' },
       token
     );
@@ -66,7 +65,7 @@ class ApiService {
   // Groups
   async createGroup(name: string, goalDescription: string, token: string): Promise<GroupWithQR> {
     return this.request<GroupWithQR>(
-      `${API_BASE_URL}/groups/`,
+      buildApiUrl('/groups/'),
       {
         method: 'POST',
         body: JSON.stringify({
@@ -79,16 +78,16 @@ class ApiService {
   }
 
   async getGroups(token: string): Promise<Group[]> {
-    return this.request<Group[]>(`${API_BASE_URL}/groups/`, {}, token);
+    return this.request<Group[]>(buildApiUrl('/groups/'), {}, token);
   }
 
   async getGroup(groupId: number, token: string): Promise<GroupWithQR> {
-    return this.request<GroupWithQR>(`${API_BASE_URL}/groups/${groupId}`, {}, token);
+    return this.request<GroupWithQR>(buildApiUrl(`/groups/${groupId}`), {}, token);
   }
 
   async joinGroup(joinCode: string, deviceId: string | null, token: string): Promise<any> {
     return this.request<any>(
-      `${API_BASE_URL}/groups/join`,
+      buildApiUrl('/groups/join'),
       {
         method: 'POST',
         body: JSON.stringify({
@@ -101,24 +100,21 @@ class ApiService {
   }
 
   async getGroupMembers(groupId: number, token: string): Promise<any> {
-    return this.request<any>(`${API_BASE_URL}/groups/${groupId}/members`, {}, token);
+    return this.request<any>(buildApiUrl(`/groups/${groupId}/members`), {}, token);
   }
 
   // Chat
   async getMessages(groupId: number, token: string): Promise<Message[]> {
-    return this.request<Message[]>(`${API_BASE_URL}/chat/${groupId}/messages`, {}, token);
+    return this.request<Message[]>(buildApiUrl(`/chat/${groupId}/messages`), {}, token);
   }
 
   async getProgress(groupId: number, token: string): Promise<ProgressEstimate[]> {
-    return this.request<ProgressEstimate[]>(`${API_BASE_URL}/chat/${groupId}/progress`, {}, token);
+    return this.request<ProgressEstimate[]>(buildApiUrl(`/chat/${groupId}/progress`), {}, token);
   }
 
   // WebSocket
   createWebSocket(groupId: number, token: string): WebSocket {
-    const wsUrl = API_BASE_URL.replace('http', 'ws');
-    // Note: In production, consider using WebSocket subprotocols or sending token
-    // in the first message after connection to avoid exposing it in URL/logs
-    return new WebSocket(`${wsUrl}/chat/ws/${groupId}?token=${token}`);
+    return new WebSocket(buildWebSocketUrl(`/chat/ws/${groupId}?token=${token}`));
   }
 }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -114,7 +114,7 @@ class ApiService {
 
   // WebSocket
   createWebSocket(groupId: number, token: string): WebSocket {
-    return new WebSocket(buildWebSocketUrl(`/chat/ws/${groupId}?token=${token}`));
+    return new WebSocket(buildWebSocketUrl(`/chat/ws/${groupId}?token=${encodeURIComponent(token)}`));
   }
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,16 +1,24 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/auth/google': 'http://localhost:8000',
-      '/auth/me': 'http://localhost:8000',
-      '/auth/set-role': 'http://localhost:8000',
-      '/groups': 'http://localhost:8000',
-      '/chat': 'http://localhost:8000'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  if (process.env.VERCEL && !env.VITE_API_URL?.trim()) {
+    throw new Error('VITE_API_URL must be set in Vercel before deploying the frontend.')
+  }
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/auth/google': 'http://localhost:8000',
+        '/auth/me': 'http://localhost:8000',
+        '/auth/set-role': 'http://localhost:8000',
+        '/groups': 'http://localhost:8000',
+        '/chat': 'http://localhost:8000'
+      }
     }
   }
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,24 +1,16 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
-
-  if (process.env.VERCEL && !env.VITE_API_URL?.trim()) {
-    throw new Error('VITE_API_URL must be set in Vercel before deploying the frontend.')
-  }
-
-  return {
-    plugins: [react()],
-    server: {
-      port: 3000,
-      proxy: {
-        '/auth/google': 'http://localhost:8000',
-        '/auth/me': 'http://localhost:8000',
-        '/auth/set-role': 'http://localhost:8000',
-        '/groups': 'http://localhost:8000',
-        '/chat': 'http://localhost:8000'
-      }
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/auth/google': 'http://localhost:8000',
+      '/auth/me': 'http://localhost:8000',
+      '/auth/set-role': 'http://localhost:8000',
+      '/groups': 'http://localhost:8000',
+      '/chat': 'http://localhost:8000'
     }
   }
 })

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+services:
+  - type: web
+    name: scio-assignment-2026-backend
+    runtime: python
+    rootDir: backend
+    plan: starter
+    region: virginia
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /health
+    disk:
+      name: student-monitor-data
+      mountPath: /var/data
+      sizeGB: 1
+    envVars:
+      - key: ENVIRONMENT
+        value: production
+      - key: SECRET_KEY
+        generateValue: true
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false
+      - key: FRONTEND_URL
+        value: https://scio-assignment-2026.vercel.app
+      - key: DATABASE_URL
+        value: sqlite:////var/data/student_monitor.db
+      - key: DEMO_ALLOW_SELF_ROLE_CHANGE
+        value: false

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     plan: starter
     region: virginia
     buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips='*'
     healthCheckPath: /health
     disk:
       name: student-monitor-data

--- a/render.yaml
+++ b/render.yaml
@@ -26,4 +26,4 @@ services:
       - key: DATABASE_URL
         value: sqlite:////var/data/student_monitor.db
       - key: DEMO_ALLOW_SELF_ROLE_CHANGE
-        value: false
+        value: "false"


### PR DESCRIPTION
## Summary
- stop production frontend builds from silently falling back to `http://localhost:8000`
- share API and WebSocket URL construction through a single helper
- validate `VITE_API_URL` and show a clearer backend configuration error for missing or malformed values
- authenticate WebSockets with an initial auth message instead of putting the token in the URL
- time out idle WebSocket auth handshakes so unauthenticated connections do not linger
- add a Render blueprint and deployment docs so the backend can be deployed and used as `VITE_API_URL`

## Validation
- `cd frontend && npm run type-check`
- `cd frontend && npm run build`
- `python -m py_compile backend/routers/auth.py backend/routers/chat.py`
- `ruby -e "require "yaml"; YAML.load_file("render.yaml"); puts "yaml-ok""`

Closes #21